### PR TITLE
Add functions for converting into and from `time` types

### DIFF
--- a/postgresql-simple-interval.cabal
+++ b/postgresql-simple-interval.cabal
@@ -28,6 +28,7 @@ common library
     base >=4.13 && <4.22,
     bytestring >=0.10.10 && <0.13,
     postgresql-simple ^>=0.7,
+    time >=1.9.3 && <1.15,
 
   default-language: Haskell2010
   ghc-options:

--- a/source/library/Database/PostgreSQL/Simple/Interval.hs
+++ b/source/library/Database/PostgreSQL/Simple/Interval.hs
@@ -1,7 +1,7 @@
 module Database.PostgreSQL.Simple.Interval
   ( Unstable.Interval (..),
 
-    -- * Constructors
+    -- * Construction
     Unstable.zero,
     Unstable.fromMicroseconds,
     Unstable.fromMilliseconds,
@@ -29,10 +29,19 @@ module Database.PostgreSQL.Simple.Interval
     Unstable.fromWeeksLiteral,
     Unstable.fromYearsLiteral,
 
+    -- * Conversion
+    Unstable.intoTime,
+    Unstable.fromTime,
+
+    -- ** Saturating
+    Unstable.fromTimeSaturating,
+
     -- * Arithmetic
     Unstable.negate,
-    Unstable.negateSaturating,
     Unstable.add,
+
+    -- ** Saturating
+    Unstable.negateSaturating,
     Unstable.addSaturating,
   )
 where


### PR DESCRIPTION
These are the most principled conversion functions I can think of. They get you into the `time` ecosystem, which lets you use functions like `addGregorianDurationClip` and `addUTCTime`. 