### PR TITLE
Add support for explicit positive infinity

### DIFF
--- a/source/library/Database/PostgreSQL/Simple/Interval/Unstable.hs
+++ b/source/library/Database/PostgreSQL/Simple/Interval/Unstable.hs
@@ -602,10 +602,11 @@ parse =
 
 parseInfinities :: A.Parser Interval
 parseInfinities =
-  -- Both `-infinity` and `infinity` are new as of PostgreSQL 17.0.
+  -- `infinity` is new as of PostgreSQL 17.0.
   -- https://www.postgresql.org/message-id/E1r2rB1-005PHm-UL%40gemulon.postgresql.org
   A.choice
     [ MkInterval minBound minBound minBound <$ "-infinity",
+      MkInterval maxBound maxBound maxBound <$ "+infinity",
       MkInterval maxBound maxBound maxBound <$ "infinity"
     ]
 

--- a/source/test-suite/Main.hs
+++ b/source/test-suite/Main.hs
@@ -394,8 +394,12 @@ spec = H.describe "Database.PostgreSQL.Simple.Interval" $ do
       let actual = Attoparsec.parseOnly I.parse "invalid"
       actual `H.shouldBe` Left "Failed reading: empty"
 
-    H.it "succeeds with positive infinity" $ do
+    H.it "succeeds with implicit positive infinity" $ do
       let actual = Attoparsec.parseOnly I.parse "infinity"
+      actual `H.shouldBe` Right (I.MkInterval maxBound maxBound maxBound)
+
+    H.it "succeeds with explicit positive infinity" $ do
+      let actual = Attoparsec.parseOnly I.parse "+infinity"
       actual `H.shouldBe` Right (I.MkInterval maxBound maxBound maxBound)
 
     H.it "succeeds with negative infinity" $ do


### PR DESCRIPTION
This allows parsing an interval like `+infinity`, which would previously fail. 